### PR TITLE
修复bug,添加解析b23.tv支持并可配置,添加单条消息解析多个视频号支持并可配置消息发送延迟时间,每条消息前加上解析的视频号,b_comments配置项(发送前三条热评)改为默认关闭

### DIFF
--- a/nonebot_plugin_biliav/__init__.py
+++ b/nonebot_plugin_biliav/__init__.py
@@ -1,17 +1,21 @@
 # import nonebot
-from nonebot import get_driver, on_regex
+import asyncio
 
+from nonebot import get_driver, on_regex
 from .config import Config
 from nonebot.typing import T_State
 from pathlib import Path
-from nonebot.adapters.onebot.v11 import Bot, Event,Message
+from nonebot.adapters.onebot.v11 import Bot, Event, Message
 from nonebot.params import T_State
 
 global_config = get_driver().config
-config = Config(**global_config.dict())
+config = global_config.dict()
+b_sleep_time = config.get('b_sleep_time', 2)
+b_sleep_time = int(b_sleep_time)
 
 from .data_source import get_av_data
 import re
+
 # Export something for other plugin
 # export = nonebot.export()
 # export.foo = "bar"
@@ -19,11 +23,17 @@ import re
 # @export.xxx
 # def some_function():
 #     pass
-biliav = on_regex("av(\d{1,12})|BV(1[A-Za-z0-9]{2}4.1.7[A-Za-z0-9]{2})")
+biliav = on_regex("[Aa][Vv]\d{1,12}|[Bb][Vv]1[A-Za-z0-9]{2}4.1.7[A-Za-z0-9]{2}|[Bb]23\.[Tt][Vv]/[A-Za-z0-9]{7}")
+
+
 @biliav.handle()
-async def handle(bot:Bot,event:Event,state:T_State):
-    avcode = re.search('av(\d{1,12})|BV(1[A-Za-z0-9]{2}4.1.7[A-Za-z0-9]{2})', str(event.get_message()))
-    if avcode==None:
+async def handle(bot: Bot, event: Event, state: T_State):
+    avcode_list = re.compile(
+        "[Aa][Vv]\d{1,12}|[Bb][Vv]1[A-Za-z0-9]{2}4.1.7[A-Za-z0-9]{2}|[Bb]23\.[Tt][Vv]/[A-Za-z0-9]{7}").findall(
+        str(event.get_message()))
+    if not avcode_list:
         return
-    rj = await get_av_data(avcode[0])
-    await bot.send(event=event,message=rj)
+    rj_list = await get_av_data(avcode_list[0])
+    for rj in rj_list:
+        await bot.send(event=event, message=rj)
+        await asyncio.sleep(b_sleep_time)

--- a/nonebot_plugin_biliav/data_source.py
+++ b/nonebot_plugin_biliav/data_source.py
@@ -1,29 +1,48 @@
 import httpx
 import json
+import re
 import nonebot
-
 from nonebot.adapters.onebot.v11 import MessageSegment, Message, Bot, Event
 
 url = 'https://api.bilibili.com/x/web-interface/view'
 
 global_config = nonebot.get_driver().config
 config = global_config.dict()
-b_comments = config.get('b_comments',"True")
-if b_comments == "False":
-    b_comments = False
-else:
-    b_comments = True
+b_comments = config.get('b_comments', False)
+b_b23tv = config.get('b_b23tv', True)
 
+if type(b_comments) != bool and b_comments == "True":
+    b_comments = True
+else:
+    b_comments = False
+
+if type(b_b23tv) != bool and b_b23tv == "False":
+    b_b23tv = False
+else:
+    b_b23tv = True
 
 import math
+
+
+async def b23tv2bv(b23tv: str) -> str:
+    async with httpx.AsyncClient() as client:
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        r = await client.get(b23tv, headers=headers)
+    return re.findall("[Bb][Vv]1[A-Za-z0-9]{2}4.1.7[A-Za-z0-9]{2}", str(r.next_request.url))[0]
+
+
 def bv2av(Bv):
     # 1.去除Bv号前的"Bv"字符
     BvNo1 = Bv[2:]
     keys = {
-        '1':'13', '2':'12', '3':'46', '4':'31', '5':'43', '6':'18', '7':'40', '8':'28', '9':'5',
-        'A':'54', 'B':'20', 'C':'15', 'D':'8', 'E':'39', 'F':'57', 'G':'45', 'H':'36', 'J':'38', 'K':'51', 'L':'42', 'M':'49', 'N':'52', 'P':'53', 'Q':'7', 'R':'4', 'S':'9', 'T':'50', 'U':'10', 'V':'44', 'W':'34', 'X':'6', 'Y':'25', 'Z':'1',
-        'a': '26', 'b': '29', 'c': '56', 'd': '3', 'e': '24', 'f': '0', 'g': '47', 'h': '27', 'i': '22', 'j': '41', 'k': '16', 'm': '11', 'n': '37', 'o': '2',
-        'p': '35', 'q': '21', 'r': '17', 's': '33', 't': '30', 'u': '48', 'v': '23', 'w': '55', 'x': '32', 'y': '14','z':'19'
+        '1': '13', '2': '12', '3': '46', '4': '31', '5': '43', '6': '18', '7': '40', '8': '28', '9': '5',
+        'A': '54', 'B': '20', 'C': '15', 'D': '8', 'E': '39', 'F': '57', 'G': '45', 'H': '36', 'J': '38', 'K': '51',
+        'L': '42', 'M': '49', 'N': '52', 'P': '53', 'Q': '7', 'R': '4', 'S': '9', 'T': '50', 'U': '10', 'V': '44',
+        'W': '34', 'X': '6', 'Y': '25', 'Z': '1',
+        'a': '26', 'b': '29', 'c': '56', 'd': '3', 'e': '24', 'f': '0', 'g': '47', 'h': '27', 'i': '22', 'j': '41',
+        'k': '16', 'm': '11', 'n': '37', 'o': '2',
+        'p': '35', 'q': '21', 'r': '17', 's': '33', 't': '30', 'u': '48', 'v': '23', 'w': '55', 'x': '32', 'y': '14',
+        'z': '19'
 
     }
     # 2. 将key对应的value存入一个列表
@@ -55,17 +74,19 @@ def bv2av(Bv):
 
     return sum ^ temp
 
-async def get_top_comments(av:str):
-    av= str(av)
+
+async def get_top_comments(av: str):
+    av = str(av)
     if av[0:2] == "BV":
-        avcode= bv2av(av)
+        avcode = bv2av(av)
     else:
-        avcode = av.replace("av","")
+        avcode = av.replace("av", "")
     async with httpx.AsyncClient() as client:
         headers = {'Content-Type': "application/x-www-form-urlencoded"}
-        r = await client.get(url=f'https://api.bilibili.com/x/v2/reply/main?next=0&type=1&oid={avcode}', headers=headers)
-    rd =  json.loads(r.text)
-    if rd['code']=="0":
+        r = await client.get(url=f'https://api.bilibili.com/x/v2/reply/main?next=0&type=1&oid={avcode}',
+                             headers=headers)
+    rd = json.loads(r.text)
+    if rd['code'] == "0":
         if not rd["data"]:
             return None
     hot_comments = rd['data']['replies'][:3]
@@ -73,45 +94,61 @@ async def get_top_comments(av:str):
     for c in hot_comments:
         name = c['member']['uname']
         txt = c['content']['message']
-        msg +=f'{name}: {txt}\n\n'
+        msg += f'{name}: {txt}\n\n'
     return msg
 
 
+async def get_av_data(av_list: list[str]) -> list[str]:
+    msg_list = []
+    for avcode in av_list:
+        msg = ""
+        if avcode[0:2].upper() == "BV":
+            avcode = bv2av(avcode)
+        elif avcode[0:2].lower() == "av":
+            avcode = avcode.replace("av", "")
+        elif avcode[0:7].lower() == "b23.tv/":
+            if b_b23tv:
+                msg += avcode + ", "
+                avcode = bv2av(b23tv2bv(avcode))
+            else:
+                continue
+        else:
+            continue
+        new_url = url + f"?aid={avcode}"
+        async with httpx.AsyncClient() as client:
+            headers = {'Content-Type': "application/x-www-form-urlencoded"}
+            r = await client.get(new_url, headers=headers)
+        rd = json.loads(r.text)
+        if rd['code'] == 0:
+            if not rd["data"]:
+                continue
+        else:
+            continue
+        msg += avcode + ":" + "\n"
+        try:
+            title = rd['data']['title']
+            pic = rd['data']['pic']
+            stat = rd['data']['stat']
+            view = stat['view']
+            danmaku = stat['danmaku']
+            reply = stat['reply']
+            fav = stat['favorite']
+            coin = stat['coin']
+            share = stat['share']
+            like = stat['like']
+            link = f"https://www.bilibili.com/video/av{avcode}"
+            desc = rd['data']['desc']
 
+            msg += "标题:" + title + "\n" + MessageSegment.image(
+                pic) + f"播放:{view} 弹幕:{danmaku} 评论:{reply} 收藏:{fav} 硬币:{coin} 分享:{share} 点赞:{like} \n点击连接进入: \n{link}\n简介: {desc}"
 
-async def get_av_data(av):
-    av= str(av)
-    if av[0:2] == "BV":
-        avcode= bv2av(av)
-    else:
-        avcode = av.replace("av","")
-    new_url =  url + f"?aid={avcode}"
-    async with httpx.AsyncClient() as client:
-        headers = {'Content-Type': "application/x-www-form-urlencoded"}
-        r = await client.get(new_url, headers=headers)
-    rd=  json.loads(r.text)
-    if rd['code']=="0":
-        if not rd["data"]:
-            return None
-    try:
-        title = rd['data']['title']
-        pic = rd['data']['pic']
-        stat = rd['data']['stat']
-        view = stat['view']
-        danmaku = stat['danmaku']
-        reply = stat['reply']
-        fav = stat['favorite']
-        coin = stat['coin']
-        share = stat['share']
-        like = stat['like']
-        link = f"https://www.bilibili.com/video/av{avcode}"
-        desc = rd['data']['desc']
+            print(msg)
+            if b_comments:
+                msg += await get_top_comments(avcode)
 
-        msg =  "标题:" + title + "\n" + MessageSegment.image(pic) + f"播放:{view} 弹幕:{danmaku} 评论:{reply} 收藏:{fav} 硬币:{coin} 分享:{share} 点赞:{like} \n点击连接进入: \n{link}\n简介: {desc}"
+            msg_list.append(msg)
+        except:
+            msg += "错误!!! 没有此av或BV号。"
 
-        print(msg)
-        if b_comments:
-            msg+=await get_top_comments(avcode)
-        return msg
-    except:
-        return "错误!!! 没有此av或BV号。"
+        msg_list.append(msg)
+    return msg_list


### PR DESCRIPTION
# 修复bug
返回值应为数字0而不是字符串"0"
https://github.com/knva/nonebot_plugin_biliav/blob/f51ceaa9bfcd6e006ac835c7170d071e4534f817/nonebot_plugin_biliav/data_source.py#L93

# 添加新功能
## 视频号开头忽略大小写
比如av,Av,BV,bv等
## 支持解析b23.tv的链接
b23.tv通常是bilibili分享时生成的短链接(包括卡片),可通过配置项目`b_b23tv=[True, False]`开启或关闭此项功能,默认开启
## 单条消息解析多个视频号
比如下面这条消息:`av170001BV17x411w7KChttps://b23.tv/m9e5LbH`,本插件收到这个消息后会发送3条视频信息的消息
同时还添加了每条消息之间的延迟控制,可以通过`b_sleep_time=[int]`配置项设置,默认为2秒
## 每条消息前加上解析的视频号
在发送多条视频信息时,便于用户一眼区分是哪个视频号的信息

# 修改
## b_comments配置项默认改为关闭,即默认不发送前三条热评,因为加上前三条热评后,消息太长
